### PR TITLE
Replaced FSiFormExtensionsBundle with IvoryCKEditorBundle

### DIFF
--- a/Form/Type/FSiAdminNews.php
+++ b/Form/Type/FSiAdminNews.php
@@ -59,11 +59,11 @@ class FSiAdminNews extends AbstractType
             'label' => 'admin.news.form.date.label',
         ));
 
-        $builder->add('introduction', 'fsi_ckeditor', array(
+        $builder->add('introduction', 'ckeditor', array(
             'label' => 'admin.news.form.introduction.label'
         ));
 
-        $builder->add('content', 'fsi_ckeditor', array(
+        $builder->add('content', 'ckeditor', array(
             'label' => 'admin.news.form.content.label'
         ));
     }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This bundle provide FSiAdminBundle configuration for FSiNewsBundle.
 
+As of now, the bundle uses [egeloen's](https://github.com/egeloen) [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle)
+instead of [FormExtensionsBundle](https://github.com/fsi-open/form-extensions-bundle) from [fsi-open](https://github.com/fsi-open).
+
 Build Status:  
 [![Build Status](https://travis-ci.org/fsi-open/admin-news-bundle.png?branch=master)](https://travis-ci.org/fsi-open/admin-news-bundle) - Master
 

--- a/composer.json
+++ b/composer.json
@@ -14,22 +14,24 @@
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
         "symfony/twig-bundle": "~2.3",
-        "fsi/admin-bundle" : "1.0.*",
         "egeloen/ckeditor-bundle": "~2.0",
+        "fsi/admin-bundle" : "1.0.*",
         "fsi/news-bundle": "dev-master"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "dev-master",
         "doctrine/orm": "~2.3",
+        "symfony/validator": "~2.3",
         "fzaninotto/faker": "v1.3.0",
-        "phpspec/phpspec": "2.0.*@dev",
-        "behat/behat": "2.4.*@stable",
-        "behat/symfony2-extension": "*@stable",
+        "phpspec/phpspec": "~2.0",
+        "behat/behat": "~2.5.0",
+        "behat/mink": "1.5.*",
         "behat/mink-extension": "*",
-        "behat/mink-browserkit-driver": "*",
-        "behat/mink-selenium2-driver": "*",
-        "sensiolabs/behat-page-object-extension": "1.0.*@dev",
-        "bossa/phpspec2-expect": "dev-master"
+        "behat/mink-browserkit-driver": "1.1.*",
+        "behat/mink-selenium2-driver": "1.1.*",
+        "behat/symfony2-extension": "*",
+        "sensiolabs/behat-page-object-extension": "1.0.4",
+        "bossa/phpspec2-expect": "*@dev"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/framework-bundle": "~2.3",
         "symfony/twig-bundle": "~2.3",
         "fsi/admin-bundle" : "1.0.*",
-        "fsi/form-extensions-bundle": "1.0.*",
+        "egeloen/ckeditor-bundle": "~2.0",
         "fsi/news-bundle": "dev-master"
     },
     "require-dev": {

--- a/features/fixtures/project/app/AppKernel.php
+++ b/features/fixtures/project/app/AppKernel.php
@@ -23,7 +23,7 @@ class AppKernel extends Kernel
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new FSi\Bundle\NewsBundle\FSiNewsBundle(),
 
-            new FSi\Bundle\FormExtensionsBundle\FSiFormExtensionsBundle(),
+            new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
             new FSi\Bundle\AdminNewsBundle\FSiAdminNewsBundle(),
             new FSi\FixturesBundle\FSiFixturesBundle(),
         );

--- a/spec/FSi/Bundle/AdminNewsBundle/Form/Type/FSiAdminNewsSpec.php
+++ b/spec/FSi/Bundle/AdminNewsBundle/Form/Type/FSiAdminNewsSpec.php
@@ -3,7 +3,6 @@
 namespace spec\FSi\Bundle\AdminNewsBundle\Form\Type;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -34,11 +33,11 @@ class FSiAdminNewsSpec extends ObjectBehavior
             'label' => 'admin.news.form.date.label',
         ))->shouldBeCalled();
 
-        $builder->add('introduction', 'fsi_ckeditor', array(
+        $builder->add('introduction', 'ckeditor', array(
             'label' => 'admin.news.form.introduction.label'
         ))->shouldBeCalled();
 
-        $builder->add('content', 'fsi_ckeditor', array(
+        $builder->add('content', 'ckeditor', array(
             'label' => 'admin.news.form.content.label'
         ))->shouldBeCalled();
 


### PR DESCRIPTION
FSiFormExtensionsBundle is no longer maintaned and thus needs to be replaced.